### PR TITLE
change type of time fields for postgres compatibility

### DIFF
--- a/force/client.go
+++ b/force/client.go
@@ -136,6 +136,7 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 	if objectUnmarshalErr != nil {
 		// Not a force.com api error. Just an unmarshalling error.
 		return fmt.Errorf("Unable to unmarshal response to object: %v", objectUnmarshalErr)
+
 	}
 
 	// Sometimes no response is expected. For example delete and update. We still have to make sure an error wasn't returned.

--- a/sobjects/base.go
+++ b/sobjects/base.go
@@ -3,6 +3,7 @@ package sobjects
 import (
 	"reflect"
 	"strings"
+	"time"
 )
 
 var baseFieldNameMap map[string]string
@@ -26,11 +27,11 @@ type BaseSObject struct {
 	Id               string            `force:",omitempty" json:",omitempty"`
 	IsDeleted        bool              `force:",omitempty" json:",omitempty"`
 	Name             string            `force:",omitempty" json:",omitempty"`
-	CreatedDate      string            `force:",omitempty" json:",omitempty"`
+	CreatedDate      time.Time         `force:",omitempty" json:",omitempty"`
 	CreatedById      string            `force:",omitempty" json:",omitempty"`
-	LastModifiedDate string            `force:",omitempty" json:",omitempty"`
+	LastModifiedDate time.Time         `force:",omitempty" json:",omitempty"`
 	LastModifiedById string            `force:",omitempty" json:",omitempty"`
-	SystemModstamp   string            `force:",omitempty" json:",omitempty"`
+	SystemModstamp   time.Time         `force:",omitempty" json:",omitempty"`
 }
 
 type SObjectAttributes struct {


### PR DESCRIPTION
Update sobject definition to change string to time.Time for time fields to address the pq error messages